### PR TITLE
Add tests and fix broken benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ __pycache__
 *.idb
 *.pdb
 *.ipch
-*.json
 *.sqlite
 *.suo
 *.obj
@@ -64,33 +63,12 @@ htmlcov
 # Translations
 *.mo
 
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-.idea
-*.iml
-*.komodoproject
-
 # Complexity
 output/*.html
 output/*/index.html
 
 # Sphinx
 docs/_build
-
-.DS_Store
-*~
-.*.sw[po]
-.build
-.ve
-.env
-.cache
-.pytest
-.benchmarks
-.bootstrap
-.appveyor.token
-*.bak
 
 # Mypy Cache
 .mypy_cache/

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,85 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "fast_numpy_loops",
+
+    // The project's homepage
+    "project_url": "https://quansight.github.io/numpy-threading-extensions/stable/index.html",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+    "branches": ["main"],
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/Qaunsight/numpy-threading-extensions.git",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    //"pythons": ["3.7"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "numpy": [],
+    },
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    "build_cache_size": 8,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // }
+}

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -1,0 +1,79 @@
+import numpy as np
+import fast_numpy_loops
+import pytest
+fast_numpy_loops.initialize()
+
+
+rng = np.random.default_rng(123456)
+
+def type2dtype(types):
+    """
+    Maps the ufunc.type to the input, output dtypes.
+    type2dtype('ii->?') -> (np.int32, np.int32), (np.bool_,)
+    """
+    inp, out = types.split('->')
+    return tuple(np.dtype(c) for c in inp), tuple(np.dtype(c) for c in out)
+
+def get_ufuncs_and_types():
+    """Create a dictionary with keys of ufunc names and values of all the
+    supported type signatures
+    """
+    ufuncs = [x for x in dir(np) if isinstance(getattr(np, x), np.ufunc)]
+    # Maybe use a collections.defaultdict instead?
+    ret = dict([[x, []] for x in ufuncs])
+    for s in ret:
+        ret[s] = [type2dtype(t) for t in getattr(np, s).types]
+    return ret
+
+def fill_random(a):
+    """Fill an ndarray with random values. This will uniformly cover the
+    bit-valued number space, which in the case of floats is differnt from
+    rng.uniform()
+    """
+    if a.dtype == 'object':
+        v = a.reshape(-1)
+        # Slow !!!
+        for i in range(v.size):
+            v[i] = float(rng._bit_generator.random_raw(1))
+    else:
+        v = a.view(np.uint64)
+        v[:] = rng._bit_generator.random_raw(v.size).reshape(v.shape)
+    return a
+
+typemap = get_ufuncs_and_types()
+
+def data(in_dtypes, out_dtypes, shape):
+    """ Return two tuples: input and output, with random data dtypes and
+    shape
+    """
+    ret_in = [fill_random(np.empty(shape, dtype=d)) for d in in_dtypes]
+    ret_out = tuple([fill_random(np.empty(shape, dtype=d)) for d in out_dtypes])
+    return ret_in, ret_out
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.parametrize(['name', 'types'], ([k, v] for k,v in typemap.items()))
+def test_threads(name, types):
+    """ Test that enabling the threading does not change the results
+    """
+    ufunc = getattr(np, name)
+    for in_dtypes, out_dtypes in types:
+        # Skip object dtypes
+        if any([o == 'object' for o in out_dtypes]):
+            continue
+        if any([o == 'object' for o in in_dtypes]):
+            continue
+        in_data, out_data = data(in_dtypes, out_dtypes, [1024, 1024])
+        if (name in ('power',) and 
+                issubclass(in_data[1].dtype.type, np.integer)):
+            in_data[1] = np.abs(in_data[1])
+            in_data[1][in_data[1] < 0] = 0
+        if len(out_data) == 1:
+            out_data = out_data[0]
+        out1 = ufunc(*in_data, out=out_data)
+        fast_numpy_loops.thread_enable()
+        assert fast_numpy_loops.thread_isenabled()
+        out2 = ufunc(*in_data, out=out_data)
+        fast_numpy_loops.thread_disable()
+        # may not work on datetime
+        if not any([o == 'datetime64' for o in out_dtypes]):
+            np.testing.assert_allclose(out1, out2, equal_nan=True)


### PR DESCRIPTION
- Added a test for all the ufuncs and types with/without threading
- The original benchmark branch was faulty: there was a file missing. Recreate it.
- Tweak the benchmarks to use 1024x1024 arrays, which should be enough to show threading improvements.

On my machine the threading apparently does not kick in. To reproduce, `pip install asv` and the `asv run HEAD~1..HEAD` to run benchmarks on a single commit. The benchmark runs multiple times on each ufunc, using three values of `thread_setworkers`. The times are all the same.