### PR TITLE
DOC: push only on merge, not on PR

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,6 +69,10 @@ jobs:
         python -m pip install --progress-bar=off -r doc_requirements.txt
         make html
         popd
+
+    - name: push rendered docs
+      if: github.event.pull_request.merged
+      run: |
         git fetch origin site
         git checkout site
         target=main  # fixme: use $GIT_BRANCH or so
@@ -83,9 +87,4 @@ jobs:
         git config user.name "mattibot"
         # If there aren't changes, doesn't make a commit; push will be a no-op
         git commit -m "auto-generating sphinx docs" || true
-    
-    - name: Push
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ github.token }}
-        branch: site
+        git push


### PR DESCRIPTION
Only `git push` from the main repo (after a merge).