### PR TITLE
Fix threading support in some benchmarks

### DIFF
--- a/benchmarks/bench_ufunc.py
+++ b/benchmarks/bench_ufunc.py
@@ -1,8 +1,45 @@
+import functools
+import os
+from typing import List, Mapping, Optional, Tuple
+
 import numpy as np
 import pnumpy
 pnumpy.initialize()
 
 
+########
+# TODO: Additional benchmarking aspects that should be incorporated into the benchmarks below:
+#       * start-of-array address alignment to 1/2/4/8/16/32/64/128-byte boundary to look for perf issues
+#         caused by things like missing some loop-peeling step (to process the first part of an array to
+#         get to an SIMD-vector-aligned boundary).
+#       * striding -- e.g. compare the performance of some function operating on an array of N elements
+#         vs. an array with the same number of elements but using a non-default stride (e.g. create an array
+#         2/3/4x the size then use slicing syntax with an explicit step value); maybe also include a 3rd
+#         comparison point where we use slicing syntax on the original array to take every other element
+#         (since that array/view would cover the same amount of memory but a smaller number of elements).
+#       * Can we report additional information at the process level (of the asv invocation)? Or would this
+#         need to be implemented in asv itself? It would be nice to use 'hwloc' to capture system topology
+#         info and save it as e.g. some metadata of the benchmark results, so we can consider doing some
+#         post-processing of the benchmark results to normalize by things like L2/L3 cache size, number of cores,
+#         SMT on/off (and SMT level), number of memory channels, etc.
+#       * Chunk/block size (in bytes, *not* number of elements) that arrays are (virtually) split into for
+#         parallel processing. The best value for this parameter will vary by function, CPU/memory characteristics,
+#         and (likely) the number of worker threads being used for that function.
+#
+#         See academic literature on automatic, empirical performance optimization of software for
+#         examples of how parameterizing settings like the # of worker threads and the chunk/block
+#         size per function on each users' machine can be used to squeeze out a little extra performance.
+#         References (not an exhaustive list):
+#           * "Automated Empirical Optimization of Software and the ATLAS Project"
+#             https://doi.org/10.1016%2FS0167-8191%2800%2900087-9
+#           * "Automated empirical tuning of scientific codes for performance and power consumption"
+#             https://dl.acm.org/doi/abs/10.1145/1944862.1944880
+#           * "Stencil computation optimization and auto-tuning on state-of-the-art multicore architectures"
+#             https://www.osti.gov/servlets/purl/964371-KongKj/
+#           * "Combining models and guided empirical search to optimize for multiple levels of the memory hierarchy"
+#             http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.532.9511
+#           * "Statistical Models for Empirical Search-Based Performance Tuning"
+#             https://dl.acm.org/doi/abs/10.1177/1094342004041293
 ########
 
 import random
@@ -15,11 +52,17 @@ random.seed(1)
 # but will seed it nevertheless
 np.random.seed(1)
 
-# Size of square 2d arrays to use in benchmarks
-nxy = 1024
+# Shape (not memory size) of rectangular 2d arrays to use in benchmarks;
+# these are also reshaped to 1d.
+# Choose non-power-of-two values for the dimensions; the product should be large enough
+# so generated arrays (of most/all dtypes) are larger than a typical machine's L3 cache.
+#nx, ny = (8009, 8011)
+#nx, ny = (4001, 4003)
+nx, ny = (1019, 1021)
+nxy = nx * ny
 
 # a set of interesting types to test
-TYPES1 = [
+TYPES1: List[str] = [
     'int16', 'float16',
     'int32', 'float32',
     'int64', 'float64',  'complex64',
@@ -45,22 +88,31 @@ def memoize(func):
 @memoize
 def get_values():
     rnd = np.random.RandomState(1)
-    values = np.tile(rnd.uniform(0, 100, size=nxy * nxy//32), 32)
+    values = np.tile(rnd.uniform(0, 100, size=nx), ny)
     return values
 
 
 @memoize
 def get_squares():
     values = get_values()
-    squares = {t: np.array(values,
-                              dtype=getattr(np, t)).reshape((nxy, nxy))
-               for t in TYPES1}
+    squares = {
+        # TODO: This approach already causes the 'values' array data to be copied here,
+        #       so maybe it's better to just decorate get_values() with functools.lru_cache() and
+        #       allow it to accept a dtype parameter? That'd also give us better control over
+        #       the distribution of the values in the generated arrays, since we'd be able to e.g.
+        #       set the lower/upper bounds of the distribution based on the range of the dtype
+        #       (from np.iinfo/np.finfo).
+        t: np.array(values, dtype=getattr(np, t)).reshape((nx, ny))
+        for t in TYPES1
+    }
 
-    # adjust complex ones to have non-degenerated imagery part -- use
-    # original data transposed for that
+    # adjust complex ones to have non-degenerate imaginary part -- use
+    # original data transposed for that.
     for t, v in squares.items():
         if t.startswith('complex'):
-            v += v.T*1j
+            # TODO: Does this still have the desired effect after transposing back again?
+            #       That's a workaround for the shapes not being compatible in the original form.
+            v += (v.T*1j).T
     return squares
 
 
@@ -91,89 +143,273 @@ def get_indexes_rand():
     indexes_rand = np.array(indexes_rand)
     return indexes_rand
 
+
+# TODO: Replace this -- we should be able to just define a setup_cache() method
+#       within the BitwiseOps class instead.
+@functools.lru_cache(maxsize=5)
+def get_shaped_ones(shape: Tuple[int, ...], dtype):
+    return np.ones(shape, dtype=dtype)
+
 ########
 
 
-
-ufuncs = ['abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
-          'arctan', 'arctan2', 'arctanh', 'bitwise_and', 'bitwise_not',
-          'bitwise_or', 'bitwise_xor', 'cbrt', 'ceil', 'conj', 'conjugate',
-          'copysign', 'cos', 'cosh', 'deg2rad', 'degrees', 'divide', 'divmod',
-          'equal', 'exp', 'exp2', 'expm1', 'fabs', 'float_power', 'floor',
-          'floor_divide', 'fmax', 'fmin', 'fmod', 'frexp', 'gcd', 'greater',
-          'greater_equal', 'heaviside', 'hypot', 'invert', 'isfinite',
-          'isinf', 'isnan', 'isnat', 'lcm', 'ldexp', 'left_shift', 'less',
-          'less_equal', 'log', 'log10', 'log1p', 'log2', 'logaddexp',
-          'logaddexp2', 'logical_and', 'logical_not', 'logical_or',
-          'logical_xor', 'matmul', 'maximum', 'minimum', 'mod', 'modf', 'multiply',
-          'negative', 'nextafter', 'not_equal', 'positive', 'power',
-          'rad2deg', 'radians', 'reciprocal', 'remainder', 'right_shift',
-          'rint', 'sign', 'signbit', 'sin', 'sinh', 'spacing', 'sqrt',
-          'square', 'subtract', 'tan', 'tanh', 'true_divide', 'trunc']
-
-
+# TODO: Get this list by introspecting numpy rather than hard-coding, so we ensure every ufunc
+#       gets benchmarked -- that way, if a new ufunc is implemented in numpy it's automatically
+#       included starting with the next benchmark run.
+#np_dict = {n: getattr(np, n) for n in dir(np)}
+#np_ufuncs = {k: v for k, v in np_dict.items() if isinstance(v, np.ufunc)}
+#np_funcs = {k: v for k, v in np_dict.items() if type(v).__qualname__ == 'function'}
+ufuncs = [
+    'abs', 'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh',
+    'arctan', 'arctan2', 'arctanh', 'bitwise_and', 'bitwise_not',
+    'bitwise_or', 'bitwise_xor', 'cbrt', 'ceil', 'conj', 'conjugate',
+    'copysign', 'cos', 'cosh', 'deg2rad', 'degrees', 'divide', 'divmod',
+    'equal', 'exp', 'exp2', 'expm1', 'fabs', 'float_power', 'floor',
+    'floor_divide', 'fmax', 'fmin', 'fmod', 'frexp', 'gcd', 'greater',
+    'greater_equal', 'heaviside', 'hypot', 'invert', 'isfinite',
+    'isinf', 'isnan', 'isnat', 'lcm', 'ldexp', 'left_shift', 'less',
+    'less_equal', 'log', 'log10', 'log1p', 'log2', 'logaddexp',
+    'logaddexp2', 'logical_and', 'logical_not', 'logical_or',
+    'logical_xor', 'matmul', 'maximum', 'minimum', 'mod', 'modf', 'multiply',
+    'negative', 'nextafter', 'not_equal', 'positive', 'power',
+    'rad2deg', 'radians', 'reciprocal', 'remainder', 'right_shift',
+    'rint', 'sign', 'signbit', 'sin', 'sinh', 'spacing', 'sqrt',
+    'square', 'subtract', 'tan', 'tanh', 'true_divide', 'trunc'
+]
 for name in dir(np):
     if isinstance(getattr(np, name, None), np.ufunc) and name not in ufuncs:
         print("Missing ufunc %r" % (name,))
 
+
+
+class BenchUtil:
+    @staticmethod
+    def set_atop_thread_count(ufunc_name: str, elem_type: np.dtype, num_threads: Optional[int]) -> None:
+        """
+        Set the number of worker threads used by atop for a given ufunc and dtype; if set to zero/None, disables threading.
+
+        TODO: What number of worker threads does atop use if given a mix of dtypes? E.g. the following:
+              num_elems = 100_000
+              left = np.ones(num_elems, dtype=np.int32)
+              right = np.ones(num_elems, dtype=np.int16)
+              np.add(left, right, dtype=np.int64)
+        """
+        if isinstance(elem_type, (str, type)):
+            elem_type = np.dtype(elem_type)
+
+        if num_threads is not None and num_threads > 0:
+            pnumpy.atop_enable()
+            # Current implementation in atop requires the number of threads to be set
+            # after calling atop_enable(), otherwise setting the number of worker threads
+            # doesn't have any effect.
+            if not pnumpy.atop_setworkers(ufunc_name, elem_type.num, num_threads):
+                # TODO: Call failed, should probably raise an exception or at least log it.
+                pass
+        else:
+            pnumpy.atop_disable()
+
+    @staticmethod
+    def set_pnumpy_thread_count(num_threads: Optional[int]) -> None:
+        """
+        Set the number of worker threads used by pnumpy; if set to zero/None, disables threading.
+        """
+        if num_threads is not None and num_threads > 0:
+            pnumpy.thread_enable()
+            pnumpy.thread_setworkers(num_threads)
+        else:
+            pnumpy.thread_disable()
+
+
+# Create the benchmark classes -- one for each ufunc.
 for ufunc in ufuncs:
     class UFunc():
-        params = [0, 2, 4]
-        param_names = ['nthreads']
+        params = (
+            # array rank
+            [1, 2],
+
+            # dtype
+            # Parameterizing by dtype lets us easily see if some ufunc isn't being optimized for a
+            # specific dtype, and to compare the performance of the ufunc across dtypes
+            # (e.g. int16 vs. int32, or int32 vs. uint32).
+            list(get_squares().keys()),
+
+            # nthreads
+            # TODO: Choose these values based on the number of cores in this machine (os.cpu_count()).
+            #       This can be created outside of the ufunc loop and captured here instead of recreating.
+            #       Might want to use the 'hwloc' library for this so we can reliably detect CPU cores
+            #       that support SMT (and determine whether it's enabled, and whether it's SMT2/4/8).
+            #       Also need to account for whether this process has been restricted to run on a subset
+            #       of CPU cores -- on Unix, can check that with ``len(os.sched_getaffinity(0))``.
+            [0, 2, 4],
+
+            # atop enabled?
+            [False, True]
+
+            # TODO: Add parameter for array pooling ("recycling") on/off?
+        )
+        param_names = ['rank', 'input_dtype', 'nthreads', 'atop']
         timeout = 10
 
-        def setup(self, nthreads):
+        def setup(self, rank, input_dtype: str, nthreads: int, atop):
             np.seterr(all='ignore')
-            if nthreads > 0:
-                pnumpy.thread_enable()
-                pnumpy.thread_setworkers(nthreads)
-            else:
-                pnumpy.thread_disable()
+
+            # Configure threading layer.
+            BenchUtil.set_pnumpy_thread_count(nthreads)
+            BenchUtil.set_atop_thread_count(ufunc, np.dtype(input_dtype), (nthreads if atop else None))
+
             try:
                 self.f = getattr(np, ufunc)
             except AttributeError:
-                raise NotImplementedError()
-            self.args = []
-            for t, a in get_squares().items():
-                arg = (a,) * self.f.nin
-                try:
-                    self.f(*arg)
-                except TypeError:
-                    continue
-                self.args.append(arg)
+                raise NotImplementedError(f"The installed version of numpy does not have a '{ufunc}' function.")
 
-        def time_ufunc_types(self, dummy):
+            # Build up the benchmark arguments.
+            self.args = []
+            a = get_squares()[input_dtype]
+
+            # If rank == 1, flatten the array for testing performance on 1D arrays,
+            # but do this in a way that avoids copying the original data to keep this fast.
+            if rank == 1:
+                # Creating a view then assigning the shape ensures we don't
+                # silently copy the data when we're just trying to flatten the array;
+                # see np.reshape() docs for details.
+                a_view = a.view()
+                a_view.shape = (nx * ny,)
+                a = a_view
+            elif rank == 2:
+                # Nothing to do here, the arrays are already built as 2D.
+                assert len(a.shape) == rank
+            else:
+                raise NotImplementedError(f"Benchmark does not know how to create rank-{rank} arrays.")
+
+            # TODO: Need to parameterize this to differentiate between the case where we're invoking
+            #       e.g. a binary op with the same array on both sides of the operator and the case
+            #       where we're passing two different arrays, they'll have different cache/memory behavior.
+            #       Maybe also consider (as a separate, 3-valued parameter) whether we'll pass a pre-created array in
+            #       for the 'out' parameter and whether that array is one of the operands or a separate array.
+            arg = (a,) * self.f.nin
+
+            try:
+                self.f(*arg)
+            except TypeError:
+                # Function couldn't be called with these arguments; can't proceed so raise NotImplementedError
+                # which means ASV will skip the current parameter tuple.
+                raise NotImplementedError(f"Constructed parameters were not compatible with the '{ufunc}' ufunc.")
+
+            self.args.append(arg)
+
+        def teardown(self, rank, input_dtype, nthreads, atop):
+            # Disable threading / revert to 'off' state.
+            BenchUtil.set_pnumpy_thread_count(None)
+            BenchUtil.set_atop_thread_count(ufunc, np.dtype(input_dtype), None)
+
+            # TODO: Undo the np.seterr(all='ignore') call made in the setup() function.
+
+        def time_ufunc_types(self, _dummy1, _dummy2, _dummy3, _dummy4):
             [self.f(*arg) for arg in self.args]
 
     UFunc.__name__ = 'UFunc_' + ufunc
     globals()[UFunc.__name__] = UFunc
 
-class Custom():
-    def setup(self):
-        self.b = np.ones(200000, dtype=bool)
 
-    def time_nonzero(self):
+class BitwiseOps:
+    # TODO: Define parameters for dtype, threads, array rank, array_pooling.
+    params = (
+        # array rank
+        [1, 2],
+
+        # dtype
+        # Parameterizing by dtype lets us easily see if some ufunc isn't being optimized for a
+        # specific dtype, and to compare the performance of the ufunc across dtypes
+        # (e.g. int16 vs. int32, or int32 vs. uint32).
+        [np.dtype(typecode) for typecode in np.typecodes['AllInteger']],
+
+        # nthreads
+        # TODO: Choose these values based on the number of cores in this machine (os.cpu_count()).
+        #       This can be created outside of the ufunc loop and captured here instead of recreating.
+        #       Might want to use the 'hwloc' library for this so we can reliably detect CPU cores
+        #       that support SMT (and determine whether it's enabled, and whether it's SMT2/4/8).
+        #       Also need to account for whether this process has been restricted to run on a subset
+        #       of CPU cores -- on Unix, can check that with ``len(os.sched_getaffinity(0))``.
+        [0, 2, 4],
+
+        # atop enabled?
+        [False, True]
+
+        # TODO: Add parameter for array pooling ("recycling") on/off?
+    )
+    param_names = ['rank', 'input_dtype', 'nthreads', 'atop']
+    timeout = 10
+
+
+    def setup(self, rank, input_dtype: str, nthreads: int, atop):
+        # TODO: Increase array size; perhaps also add a parameter to vary the array size; may also want to
+        #       cache the created arrays (and maybe clean them up / purge the cache during fixture teardown).
+        # TODO: Need to test (perhaps controlled by a parameter) with a second array here; as-is, the benchmarks
+        #       below test bitwise operations where the same array is on both sides of the expression; this will
+        #       have different cache/memory utilization compared to the more-typical case where we have two
+        #       different arrays. A sufficiently-clever implementation of these functions could also detect the
+        #       self-application case and use a different way of producing the result (which is interesting and
+        #       worth including in a benchmark, it just needs to be differentiated from the typical case).
+        # TODO: Create this array in a 'setup_cache' function so ASV will cache it and speed up the benchmark run.
+
+        # Configure threading layer.
+        BenchUtil.set_pnumpy_thread_count(nthreads)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(input_dtype), (nthreads if atop else None))
+
+        # Get the shape of the array to create based on the rank parameter.
+        if rank == 1:
+            b_shape = (nxy,)
+        elif rank == 2:
+            b_shape = (nx, ny)
+        else:
+            raise NotImplementedError(f"Benchmark does not know how to create rank-{rank} arrays.")
+
+        self.b = get_shaped_ones(b_shape, dtype=input_dtype)
+
+    def teardown(self, rank, input_dtype, nthreads, atop):
+        # Disable threading / revert to 'off' state.
+        BenchUtil.set_pnumpy_thread_count(None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(input_dtype), None)
+
+    def time_nonzero(self, _dummy1, _dummy2, _dummy3, _dummy4):
+        # TODO: Does this need to switch between np and pnumpy/pn?
         np.nonzero(self.b)
 
-    def time_not_bool(self):
+    def time_bitwise_not_bool(self, _dummy1, _dummy2, _dummy3, _dummy4):
         (~self.b)
 
-    def time_and_bool(self):
+    def time_bitwise_and_bool(self, _dummy1, _dummy2, _dummy3, _dummy4):
         (self.b & self.b)
 
-    def time_or_bool(self):
+    def time_bitwise_or_bool(self, _dummy1, _dummy2, _dummy3, _dummy4):
         (self.b | self.b)
 
 
-class CustomInplace():
+class CustomInplace:
     def setup(self):
-        self.c = np.ones(500000, dtype=np.int8)
-        self.i = np.ones(150000, dtype=np.int32)
-        self.f = np.zeros(150000, dtype=np.float32)
-        self.d = np.zeros(150000, dtype=np.float64)
+        # TEMP: Disable threading / revert to 'off' state until we can parameterize
+        #       this fixture with thread counts, etc.
+        BenchUtil.set_pnumpy_thread_count(None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.int8), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.int32), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.float32), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.float64), None)
+
+        self.c = np.ones(30_000_000, dtype=np.int8)
+        self.i = np.ones(3_000_000, dtype=np.int32)
+        self.f = np.zeros(3_000_000, dtype=np.float32)
+        self.d = np.zeros(3_000_000, dtype=np.float64)
         # fault memory
         self.f *= 1.
         self.d *= 1.
+
+    def teardown(self):
+        # Disable threading / revert to 'off' state.
+        BenchUtil.set_pnumpy_thread_count(None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.int8), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.int32), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.float32), None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(np.float64), None)
 
     def time_char_or(self):
         np.bitwise_or(self.c, 0, out=self.c)
@@ -204,12 +440,22 @@ class CustomInplace():
         1. + self.d + 1.
 
 
-class CustomScalar():
+class CustomScalar:
     params = [np.float32, np.float64]
     param_names = ['dtype']
 
     def setup(self, dtype):
-        self.d = np.ones(200000, dtype=dtype)
+        # TEMP: Disable threading / revert to 'off' state until we can parameterize
+        #       this fixture with thread counts, etc.
+        BenchUtil.set_pnumpy_thread_count(None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(dtype), None)
+
+        self.d = np.ones(7_000_000, dtype=dtype)
+
+    def teardown(self, dtype):
+        # Disable threading / revert to 'off' state.
+        BenchUtil.set_pnumpy_thread_count(None)
+        BenchUtil.set_atop_thread_count(ufunc, np.dtype(dtype), None)
 
     def time_add_scalar2(self, dtype):
         np.add(self.d, 1)
@@ -223,3 +469,11 @@ class CustomScalar():
     def time_less_than_scalar2(self, dtype):
         (self.d < 1)
 
+
+# TODO: Logical binary ops (e.g. logical_and).
+# TODO: Logical unary ops (e.g. logical_not)
+# TODO: Logical reductions (any, all, alltrue).
+# TODO: Fancy/bool indexing benchmarks; also: where (both 1- and 3-arg forms), putmask, copyto, choose, take.
+# TODO: Reductions (e.g. sum, var, mean, amin, amax, argmin, argmax, nanargmin, nanargmax, nansum)
+# TODO: Set ops (e.g. isin, unique)
+# TODO: Sorting


### PR DESCRIPTION
This PR fixes some (not all) of the ASV benchmarks to give proper control over the number of worker threads being used. The main ufunc benchmarks have also been modified to be parameterized over their dtype (rather than bench'ing all dtypes within a loop) to provide more-granular results.

There's still some work to be done on the benchmark suite -- which I'll continue iterating on -- but these changes do show how threading improves the performance on the ufuncs that've been implemented in ``pnumpy`` so far.

One thing that looks wrong and I haven't yet looked into -- the results from each of the ufunc benchmarks are all suspiciously similar (at least on the machine I've been testing with). There's either some large overhead that's dominating the runtime of the benchmarks, or we're doing something like invoking the same ufunc over and over. I'll dig into this within the next few days.

Here's an example of the asv output now (from ``asv run --quick``) demonstrating the performance improvement from threading. Note it also illustrates the issue I mentioned with ufunc results being oddly (and likely incorrectly) similar -- in this case, I'd expect ``equal`` to be much faster than the ``exp`` function (threading or not).

<details>
<summary>asv output excerpt</summary>

```
[ 19.63%] ··· bench_ufunc.UFunc_equal.time_ufunc_types                                                                                                                                                                                    ok
[ 19.63%] ··· ====== ============= =========== ========== =========== ========== =========== ==========
              --                                             nthreads / atop
              -------------------- --------------------------------------------------------------------
               rank   input_dtype   0 / False   0 / True   2 / False   2 / True   4 / False   4 / True
              ====== ============= =========== ========== =========== ========== =========== ==========
                1        int16       9.10±0ms   9.73±0ms    4.38±0ms   2.18±0ms    3.97±0ms   2.13±0ms
                1       float16      12.5±0ms   12.7±0ms    12.4±0ms   12.4±0ms    12.6±0ms   13.1±0ms
                1        int32       11.8±0ms   11.3±0ms    7.54±0ms   4.34±0ms    5.63±0ms   5.30±0ms
                1       float32      8.79±0ms   7.93±0ms    3.28±0ms   1.05±0ms    2.61±0ms   1.65±0ms
                1        int64       12.8±0ms   12.1±0ms    6.85±0ms   4.74±0ms    6.08±0ms   5.29±0ms
                1       float64      11.1±0ms   12.8±0ms    5.43±0ms   2.84±0ms    3.65±0ms   2.01±0ms
                1      complex64       n/a        n/a         n/a        n/a         n/a        n/a
                1      longfloat     9.40±0ms   9.76±0ms    4.42±0ms   2.38±0ms    3.63±0ms   4.38±0ms
                1      complex128      n/a        n/a         n/a        n/a         n/a        n/a
                2        int16       9.21±0ms   9.60±0ms    4.47±0ms   2.41±0ms    7.50±0ms   2.50±0ms
                2       float16      13.1±0ms   13.0±0ms    12.6±0ms   12.5±0ms    12.8±0ms   13.2±0ms
                2        int32       11.4±0ms   12.0±0ms    7.46±0ms   4.31±0ms    8.15±0ms   5.58±0ms
                2       float32      8.35±0ms   8.42±0ms    4.14±0ms   1.17±0ms    2.70±0ms   1.03±0ms
                2        int64       11.9±0ms   11.7±0ms    6.96±0ms   4.70±0ms    6.13±0ms   5.44±0ms
                2       float64      10.3±0ms   9.05±0ms    4.97±0ms   2.09±0ms    3.60±0ms   2.37±0ms
                2      complex64       n/a        n/a         n/a        n/a         n/a        n/a
                2      longfloat     9.69±0ms   9.24±0ms    4.18±0ms   2.11±0ms    3.57±0ms   2.10±0ms
                2      complex128      n/a        n/a         n/a        n/a         n/a        n/a
              ====== ============= =========== ========== =========== ========== =========== ==========

[ 20.09%] ··· bench_ufunc.UFunc_exp.time_ufunc_types                                                                                                                                                                                      ok
[ 20.09%] ··· ====== ============= =========== ========== =========== ========== =========== ==========
              --                                             nthreads / atop
              -------------------- --------------------------------------------------------------------
               rank   input_dtype   0 / False   0 / True   2 / False   2 / True   4 / False   4 / True
              ====== ============= =========== ========== =========== ========== =========== ==========
                1        int16       12.2±0ms   9.05±0ms    4.57±0ms   2.90±0ms    4.39±0ms   2.26±0ms
                1       float16      13.3±0ms   12.7±0ms    12.5±0ms   12.6±0ms    13.0±0ms   13.0±0ms
                1        int32       11.4±0ms   11.2±0ms    6.51±0ms   4.90±0ms    5.54±0ms   4.35±0ms
                1       float32      8.17±0ms   7.81±0ms    3.52±0ms   1.17±0ms    2.60±0ms   1.19±0ms
                1        int64       11.6±0ms   11.9±0ms    9.11±0ms   4.61±0ms    6.08±0ms   4.95±0ms
                1       float64      9.39±0ms   10.1±0ms    4.77±0ms   2.23±0ms    3.63±0ms   2.25±0ms
                1      complex64       n/a        n/a         n/a        n/a         n/a        n/a
                1      longfloat     9.38±0ms   9.29±0ms    4.38±0ms   2.12±0ms    3.59±0ms   2.61±0ms
                1      complex128      n/a        n/a         n/a        n/a         n/a        n/a
                2        int16       9.09±0ms   9.03±0ms    4.81±0ms   2.48±0ms    4.07±0ms   2.45±0ms
                2       float16      12.6±0ms   12.3±0ms    12.6±0ms   12.6±0ms    13.4±0ms   14.3±0ms
                2        int32       11.5±0ms   13.9±0ms    6.72±0ms   5.08±0ms    5.63±0ms   4.46±0ms
                2       float32      8.73±0ms   8.21±0ms    3.74±0ms   1.92±0ms    2.81±0ms   1.05±0ms
                2        int64       13.1±0ms   12.1±0ms    6.71±0ms   4.77±0ms    6.35±0ms   4.56±0ms
                2       float64      8.98±0ms   8.96±0ms    4.85±0ms   2.15±0ms    3.85±0ms   2.28±0ms
                2      complex64       n/a        n/a         n/a        n/a         n/a        n/a
                2      longfloat     9.26±0ms   8.92±0ms    4.39±0ms   2.26±0ms    3.64±0ms   2.27±0ms
                2      complex128      n/a        n/a         n/a        n/a         n/a        n/a
              ====== ============= =========== ========== =========== ========== =========== ==========
```
</details>
