### PR TITLE
initialize before setting nthreads

### DIFF
--- a/benchmarks/bench_ufunc.py
+++ b/benchmarks/bench_ufunc.py
@@ -238,6 +238,7 @@ class BenchUtil:
         Set the number of worker threads used by pnumpy; if set to zero/None,
         disables threading.
         """
+        pnumpy.initialize()
         if num_threads is not None and num_threads > 0:
             pnumpy.thread_enable()
             pnumpy.thread_setworkers(num_threads)


### PR DESCRIPTION
Related to [a comment](https://github.com/Quansight/numpy-threading-extensions/issues/110#issuecomment-755605721) about initializing pnumpy. Now it is initialized just before the call to  `thread_setworkers(num_threads)`

Please try running
```
$ asv run --bench isinf
· Creating environments
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pnumpy commit 97c60ed8 <main>:
[  0.00%] ·· Benchmarking virtualenv-py3.8-numpy
[ 50.00%] ··· Running (bench_ufunc.UFunc_isinf.time_ufunc_types--).
[100.00%] ··· bench_ufunc.UFunc_isinf.time_ufunc_types                                                            ok
[100.00%] ··· ====== ============= ========== ============= =============
              --                                          atop           
              ------------------------------- ---------------------------
               rank   input_dtype   nthreads      False          True    
              ====== ============= ========== ============= =============
                1        int16         0       13.5±0.04μs   13.5±0.02μs 
                1        int16         2        15.5±0.1μs    15.7±0.2μs 
                1        int16         4       15.7±0.09μs    16.0±0.2μs 
                1       float16        0         1.83±0ms      1.83±0ms  
                1       float16        2         1.83±0ms      1.83±0ms  
                1       float16        4         1.83±0ms      1.83±0ms  
                1        int32         0       13.5±0.06μs   13.6±0.04μs 
                1        int32         2        15.6±0.1μs    15.7±0.2μs 
                1        int32         4        15.7±0.1μs    15.9±0.2μs 
                1       float32        0        125±0.06μs    125±0.1μs  
                1       float32        2        128±0.1μs     634±0.3μs  
                1       float32        4        128±0.1μs     634±0.5μs  
                1        int64         0       13.6±0.03μs   13.6±0.02μs 
                1        int64         2        15.7±0.1μs    15.7±0.2μs 
                1        int64         4        15.7±0.2μs    15.9±0.2μs 
                1       float64        0        254±0.2μs      255±1μs   
                1       float64        2        257±0.3μs     634±0.9μs  
                1       float64        4        257±0.4μs     634±0.3μs  
                1      complex64       0        805±0.5μs     804±0.3μs  
                1      complex64       2        806±0.7μs     804±0.4μs  
                1      complex64       4        805±0.4μs      805±20μs  
                1      longfloat       0       6.02±0.01ms   6.02±0.01ms 
                1      longfloat       2       6.03±0.01ms     6.02±0ms  
                1      longfloat       4       6.03±0.01ms   6.02±0.01ms 
                1      complex128      0       1.02±0.01ms   1.03±0.02ms 
                1      complex128      2         1.03±0ms    1.03±0.01ms 
                1      complex128      4       1.02±0.01ms   1.03±0.01ms 
                1      complex256      0       11.6±0.01ms   11.7±0.03ms 
                1      complex256      2       11.6±0.02ms   11.6±0.01ms 
                1      complex256      4       11.6±0.01ms   11.6±0.02ms 
                2        int16         0       13.5±0.05μs   13.5±0.01μs 
                2        int16         2       15.5±0.04μs    15.5±0.1μs 
                2        int16         4       15.6±0.06μs   15.8±0.05μs 
                2       float16        0         1.83±0ms      1.83±0ms  
                2       float16        2         1.83±0ms      1.83±0ms  
                2       float16        4         1.83±0ms      1.83±0ms  
                2        int32         0       13.5±0.05μs   13.6±0.04μs 
                2        int32         2       15.5±0.05μs   15.6±0.04μs 
                2        int32         4       15.6±0.05μs   15.8±0.03μs 
                2       float32        0        125±0.2μs     126±0.2μs  
                2       float32        2        128±0.1μs     634±0.2μs  
                2       float32        4        128±0.1μs     634±0.3μs  
                2        int64         0       13.6±0.02μs   13.6±0.04μs 
                2        int64         2       15.6±0.06μs   15.6±0.08μs 
                2        int64         4       15.6±0.07μs   15.8±0.03μs 
                2       float64        0        255±0.5μs     254±0.3μs  
                2       float64        2        258±0.5μs      634±1μs   
                2       float64        4        258±0.3μs     634±0.2μs  
                2      complex64       0        805±0.4μs      805±1μs   
                2      complex64       2        804±0.3μs     805±0.2μs  
                2      complex64       4        805±0.4μs     804±0.3μs  
                2      longfloat       0       6.03±0.01ms   6.03±0.01ms 
                2      longfloat       2       6.02±0.01ms   6.03±0.01ms 
                2      longfloat       4         6.03±0ms    6.03±0.01ms 
                2      complex128      0         1.02±0ms    1.01±0.01ms 
                2      complex128      2       1.02±0.01ms   1.01±0.01ms 
                2      complex128      4       1.01±0.01ms     1.02±0ms  
                2      complex256      0       11.6±0.01ms   11.6±0.01ms 
                2      complex256      2       11.6±0.01ms   11.6±0.01ms 
                2      complex256      4       11.6±0.01ms   11.6±0.01ms 
              ====== ============= ========== ============= =============

```
from the top directory with this changeset. Note how the benchmarks do not change with the number of threads

```

```